### PR TITLE
Fix spurious connected messages

### DIFF
--- a/drivers/hubitat-mqtt-link-driver.groovy
+++ b/drivers/hubitat-mqtt-link-driver.groovy
@@ -46,6 +46,7 @@ metadata {
         	iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Connections/Cat-Connections@3x.png"
         ) {
 		capability "Notification"
+        attribute "status", ""
 
 		preferences {
 			input(
@@ -238,7 +239,7 @@ def parse(String event) {
 def mqttClientStatus(status) {
     if (status.startsWith("Status: Connection succeeded")) 
         connected()
-    else if (status.startsWith("Error: Connection lost: Connection lost"))
+    else if (status.startsWith("Error: Connection lost"))
         disconnected()
     else if (status.startsWith("Error")) 
         error("[mqttClientStatus] ${status}")
@@ -264,7 +265,7 @@ def publishMqtt(topic, payload, qos = 0, retained = false) {
 
 def connected() {
     debug("[connected] Connected to broker")
-    sendEvent (name: "connectionState", value: "connected")
+    sendEvent (name: "status", value: "connected")
     announceLwtStatus("online")
     
     state?.reconnectDelay = 1
@@ -273,7 +274,7 @@ def connected() {
 
 def disconnected() {
     debug("[disconnected] Disconnected from broker")
-    sendEvent (name: "connectionState", value: "disconnected")
+    sendEvent (name: "status", value: "disconnected")
     
     // first delay is 2 seconds, doubles every time
     state.reconnectDelay = (state.reconnectDelay ?: 1) * 2

--- a/drivers/hubitat-mqtt-link-driver.groovy
+++ b/drivers/hubitat-mqtt-link-driver.groovy
@@ -136,19 +136,11 @@ def publish(topic, payload) {
 }
 
 def subscribe(topic) {
-    if (notMqttConnected()) {
-        connect()
-    }
-
     debug("[subscribe] full topic: ${getTopicPrefix()}${topic}")
     interfaces.mqtt.subscribe("${getTopicPrefix()}${topic}")
 }
 
 def unsubscribe(topic) {
-    if (notMqttConnected()) {
-        connect()
-    }
-
     debug("[unsubscribe] full topic: ${getTopicPrefix()}${topic}")
     interfaces.mqtt.unsubscribe("${getTopicPrefix()}${topic}")
 }
@@ -244,20 +236,16 @@ def parse(String event) {
 }
 
 def mqttClientStatus(status) {
-    if (status.startsWith("status: Error")) {
-        error("${status}")
-        if (notMqttConnected()) disconnected()
-    } else {
-        debug("[mqttClientStatus] status: ${status}")
-        if (mqttConnected()) connected()
-    }   
+    if (status.startsWith("Error")) 
+        error("[mqttClientStatus] ${status}")
+    else
+        debug("[mqttClientStatus] ${status}")
+    
+    if (status.startsWith("Status: Connection succeeded")) connected()
+    if (status.startsWith("Error: Connection lost: Connection lost")) disconnected()
 }
 
 def publishMqtt(topic, payload, qos = 0, retained = false) {
-    if (notMqttConnected()) {
-        initialize()
-    }
-    
     def pubTopic = "${getTopicPrefix()}${topic}"
 
     try {
@@ -274,13 +262,13 @@ def publishMqtt(topic, payload, qos = 0, retained = false) {
 // ========================================================
 
 def connected() {
-    info("[connected] Connected to broker")
+    debug("[connected] Connected to broker")
     sendEvent (name: "connectionState", value: "connected")
     announceLwtStatus("online")
 }
 
 def disconnected() {
-    info("[disconnected] Disconnected from broker")
+    debug("[disconnected] Disconnected from broker")
     sendEvent (name: "connectionState", value: "disconnected")
     announceLwtStatus("offline")
 }

--- a/drivers/hubitat-mqtt-link-driver.groovy
+++ b/drivers/hubitat-mqtt-link-driver.groovy
@@ -30,7 +30,7 @@
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-public static String version() { return "v1.0.0" }
+public static String version() { return "v1.0.1" }
 public static String rootTopic() { return "hubitat" }
 
 //hubitat / {hub-name} / { device-name } / { device-capability } / STATE
@@ -160,6 +160,7 @@ def disconnect() {
     
     try {
         interfaces.mqtt.disconnect()
+        disconnected()
     } catch(e) {
         warn("Disconnection from broker failed", ${e.message})
     }
@@ -270,12 +271,10 @@ def publishMqtt(topic, payload, qos = 0, retained = false) {
 // ========================================================
 
 def connected() {
+    state?.reconnectDelay = 1
     debug("[connected] Connected to broker")
     sendEvent (name: "status", value: "connected")
     announceLwtStatus("online")
-    
-    state?.reconnectDelay = 1
-    state?.connectionActive = true
 }
 
 def disconnected() {
@@ -286,7 +285,6 @@ def disconnected() {
         state.reconnectDelay = (state.reconnectDelay ?: 1) * 2
         // don't def the delay get too crazy, max it out at 10 minutes
         if(state.reconnectDelay > 600) state.reconnectDelay = 600
-        state?.connectionActive = false
         runIn(state?.reconnectDelay, initialize)
     }
 }


### PR DESCRIPTION
This improves the connection handling of mqtt link so that it doesn't try and connect over and over if something is wrong.  In my testing it gravefully handled mqtt being stopped and started.  It also fixes all the logging and events that were being created by the old code.  (They were enough to slow down my hub badly)